### PR TITLE
Use IP from tracker requests

### DIFF
--- a/ExcludeByDDNS.php
+++ b/ExcludeByDDNS.php
@@ -35,7 +35,7 @@ class ExcludeByDDNS extends \Piwik\Plugin
         return true;
     }
 
-    public function checkIfIpIsExcluded(&$exclude)
+    public function checkIfIpIsExcluded(&$exclude, $request)
     {
         if ($exclude) {
             Common::printDebug("Visit is already excluded, no need to check exclusion by DDNS.");
@@ -49,7 +49,7 @@ class ExcludeByDDNS extends \Piwik\Plugin
             return; // Nothing to exclude
         }
 
-        $ip = \Matomo\Network\IP::fromStringIP(IP::getIpFromHeader());
+        $ip = \Matomo\Network\IP::fromStringIP($request->getIpString());
         if ($ip->isInRanges($excludedIPs)) {
             Common::printDebug('Visitor IP ' . $ip->toString() . ' is excluded from being tracked');
             $exclude = true;


### PR DESCRIPTION
Currently visits generated by a server-side client (such as the Matomo PHP library) are not excluded as expected.

This changes the plugin to exclude by using `$request->getIpString()`. Which returns the `cip` value from a properly authenticated request, instead of the remote address.

Thanks for this plugin!